### PR TITLE
allowed null tree score

### DIFF
--- a/aggregate_json/code/aggregate.schema
+++ b/aggregate_json/code/aggregate.schema
@@ -70,7 +70,7 @@
                 "properties": {
                     "tree_id": {"type": "number"},
                     "tree_name": {"type": "string"},
-                    "tree_score": {"type": "number"},
+                    "tree_score": {"type": ["number", "null"]},
                     "nodes": {
                         "type": "array",
                         "items": {


### PR DESCRIPTION
Hi Chuanyi, I found that the schema must explicitly allow null for the tree_score property in order for our files to validate. This PR changes the schema accordingly.